### PR TITLE
ugps: add quality measurement parameters

### DIFF
--- a/main.c
+++ b/main.c
@@ -66,6 +66,10 @@ gps_info(struct ubus_context *ctx, struct ubus_object *obj,
 			blobmsg_add_string(&b, "course", course);
 		if (gps_fields & GPS_FIELD_SPD)
 			blobmsg_add_string(&b, "speed", speed);
+		if (gps_fields & GPS_FIELD_SAT)
+			blobmsg_add_string(&b, "satellites", satellites);
+		if (gps_fields & GPS_FIELD_HDP)
+			blobmsg_add_string(&b, "HDOP", hdop);
 	}
 	ubus_send_reply(ctx, req, b.head);
 

--- a/nmea.c
+++ b/nmea.c
@@ -52,7 +52,7 @@ struct nmea_param {
 } nmea_params[MAX_NMEA_PARAM];
 
 static int nmea_bad_time;
-char longitude[33] = { 0 }, latitude[33] = { 0 }, course[17] = { 0 }, speed[17] = { 0 }, elevation[17] = { 0 };
+char longitude[33] = { 0 }, latitude[33] = { 0 }, course[17] = { 0 }, speed[17] = { 0 }, elevation[17] = { 0 }, satellites[3] = { 0 }, hdop[5] = { 0 };
 int gps_valid = 0;
 char gps_fields = 0;
 
@@ -222,8 +222,12 @@ nmea_gga_cb(void)
 {
 	if (!gps_valid)
 		return;
+	strncpy(satellites, nmea_params[7].str, sizeof(satellites));
+ 	strncpy(hdop, nmea_params[8].str, sizeof(hdop));
 	strncpy(elevation, nmea_params[9].str, sizeof(elevation));
-	gps_fields |= GPS_FIELD_ALT;
+	gps_fields |= GPS_FIELD_SAT | GPS_FIELD_HDP | GPS_FIELD_ALT;
+	DEBUG(4, "satellites: %s\n", satellites);
+ 	DEBUG(4, "HDOP: %s\n", hdop);
 	DEBUG(4, "height: %s\n", elevation);
 }
 

--- a/nmea.h
+++ b/nmea.h
@@ -23,7 +23,7 @@
 
 #include <libubox/ustream.h>
 
-extern char longitude[33], latitude[33], course[17], speed[17], elevation[17], satellites[3], hdop[5];;
+extern char longitude[33], latitude[33], course[17], speed[17], elevation[17], satellites[3], hdop[5];
 extern int nmea_open(char *dev, struct ustream_fd *s, speed_t speed);
 extern void gps_timestamp(void);
 extern unsigned int adjust_clock;

--- a/nmea.h
+++ b/nmea.h
@@ -23,7 +23,7 @@
 
 #include <libubox/ustream.h>
 
-extern char longitude[33], latitude[33], course[17], speed[17], elevation[17];
+extern char longitude[33], latitude[33], course[17], speed[17], elevation[17], satellites[3], hdop[5];;
 extern int nmea_open(char *dev, struct ustream_fd *s, speed_t speed);
 extern void gps_timestamp(void);
 extern unsigned int adjust_clock;
@@ -33,5 +33,7 @@ extern char gps_fields;
 #define GPS_FIELD_COG (1<<2)
 #define GPS_FIELD_SPD (1<<3)
 #define GPS_FIELD_ALT (1<<4)
+#define GPS_FIELD_SAT (1<<5)
+#define GPS_FIELD_HDP (1<<6)
 
 #endif


### PR DESCRIPTION
The current version of ugps does not report any quality parameters for GPS receiver fixation. Considering the positioning error, which can be up to hundreds of meters, it is helpful to know how accurately the GPS determines the position. 

This PR supports determining the number of satellites and the HDOP (Horizontal Dilution of Precision) parameter to address this. 

The GPGGA sentence is already parsed in the code, so it just extends the amount of data it reads.